### PR TITLE
prep for `v0.15.0` release

### DIFF
--- a/src/archive.php
+++ b/src/archive.php
@@ -54,12 +54,6 @@
         </ul>
     </nav> -->
 
-    <article class="attention">
-        <h2>Write a post!</h2>
-        <p>We accept <a href="#">proposals and submissions for posts</a> related to our mission and the commons.</p>
-
-    </article>
-
 
 </aside>
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -99,6 +99,43 @@ function exclude_highlights_id ( $args, $field, $post ) {
   return $args;
 }
 
+function custom_sidebar_menu_fallback_full() {
+  $homepage = get_page_by_path( 'homepage' );
+  $homepageID = $homepage->ID;
+
+  $output = wp_list_pages( array(
+    'echo'     => 0,
+    'exclude'  => $homepageID,
+    'depth'    => 1,
+     'title_li' => ''
+  ) );
+
+  if ( is_page() ) {
+    $page = $post->ID;
+    if ( $post->post_parent ) {
+      $page = $post->post_parent;
+    }
+
+    $children = wp_list_pages( array(
+      'echo'     => 0,
+      'exclude'  => $homepageID,
+      'child_of' => $page,
+      'title_li' => ''
+    ) );
+
+    if ( $children ) {
+      $output = wp_list_pages( array(
+        'echo' => 0,
+        'exclude'  => $homepageID,
+        'child_of' => $page,
+        'title_li' => ''
+      ) );
+    }
+  }
+  echo '<ul class="default">';
+  echo $output;
+  echo '</ul>';
+}
 
 
 function custom_sidebar_menu_fallback() {

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,27 +2,27 @@
 
 // SECURITY
 // remove output of wordpress version in source
-//remove_action('wp_head', 'wp_generator');
+remove_action('wp_head', 'wp_generator');
 
 // remove Customize menu
-// add_action('admin_menu', function () {
-//   global $submenu;
+add_action('admin_menu', function () {
+  global $submenu;
 
-//   foreach ($submenu as $name => $items) {
-//       if ($name === 'themes.php') {
-//           foreach ($items as $i => $data) {
-//               if (in_array('customize', $data, true)) {
-//                   unset($submenu[$name][$i]);
+  foreach ($submenu as $name => $items) {
+      if ($name === 'themes.php') {
+          foreach ($items as $i => $data) {
+              if (in_array('customize', $data, true)) {
+                  unset($submenu[$name][$i]);
 
-//                   return;
-//               }
-//           }
-//       }
-//   }
-// });
+                  return;
+              }
+          }
+      }
+  }
+});
 
 // remove GUI file editor
-//define('DISALLOW_FILE_EDIT', TRUE);
+define('DISALLOW_FILE_EDIT', TRUE);
 
 // GENERAL WP
 // add menu locations

--- a/src/header.php
+++ b/src/header.php
@@ -20,8 +20,8 @@
         <!-- below menu is not final items, for testing only -->
         <nav class="primary-menu">
             <ul>
-                <li><a href="/about">Who We Are</a></li>
-                <li><a href="/programs">What We Do</a></li>
+                <li><a href="/about/mission">Who We Are</a></li>
+                <li><a href="/about">What We Do</a></li>
                 <li><a href="/share-your-work">Licenses and Tools</a></li>
                 <li><a href="/blog">Blog</a></li>
                 <li><a href="/about/support-cc/">Support Us</a></li>

--- a/src/inc/acf-json/group_64f1fb809e42b.json
+++ b/src/inc/acf-json/group_64f1fb809e42b.json
@@ -130,6 +130,26 @@
                 "param": "post_template",
                 "operator": "!=",
                 "value": "page_static.php"
+            },
+            {
+                "param": "post_template",
+                "operator": "!=",
+                "value": "page_blog.php"
+            },
+            {
+                "param": "post_template",
+                "operator": "!=",
+                "value": "page_home.php"
+            },
+            {
+                "param": "post_template",
+                "operator": "!=",
+                "value": "page_team.php"
+            },
+            {
+                "param": "post_template",
+                "operator": "!=",
+                "value": "page_walkthrough.php"
             }
         ]
     ],
@@ -142,5 +162,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1694632329
+    "modified": 1695403547
 }

--- a/src/inc/acf-json/post_type_64e619a456784.json
+++ b/src/inc/acf-json/post_type_64e619a456784.json
@@ -45,7 +45,7 @@
     "description": "",
     "public": true,
     "hierarchical": false,
-    "exclude_from_search": false,
+    "exclude_from_search": true,
     "publicly_queryable": true,
     "show_ui": true,
     "show_in_menu": true,
@@ -81,5 +81,5 @@
     "delete_with_user": false,
     "register_meta_box_cb": "",
     "enter_title_here": "",
-    "modified": 1694632368
+    "modified": 1695330885
 }

--- a/src/page-archive.php
+++ b/src/page-archive.php
@@ -45,12 +45,6 @@
         </ul>
     </nav> -->
 
-    <article class="attention">
-        <h2>Write a post!</h2>
-        <p>We accept <a href="#">proposals and submissions for posts</a> related to our mission and the commons.</p>
-
-    </article>
-
 
 </aside>
 

--- a/src/page-archive.php
+++ b/src/page-archive.php
@@ -13,8 +13,6 @@
 
 <h1>Archives</h1>
 
-<p>lead in paragraph</p>
-
 </header>
 
 <aside>

--- a/src/page_blog.php
+++ b/src/page_blog.php
@@ -115,7 +115,7 @@
 $query = new WP_Query(array(
     'post__not_in' => $highlight_posts,
     'post_type' => 'post',
-    'posts_per_page' => 5,
+    'posts_per_page' => 6,
     //'paged' => $paged,
 ));
 ?>

--- a/src/page_home.php
+++ b/src/page_home.php
@@ -57,8 +57,8 @@ get_header('', array( 'body-classes' => 'home-narrative') );
             <?php
 
                $firstDataPointImage = get_field('first_data_point_image');
-               $secondDataPointImage = get_field('first_data_point_image');
-               $thirdDataPointImage = get_field('first_data_point_image');
+               $secondDataPointImage = get_field('second_data_point_image');
+               $thirdDataPointImage = get_field('third_data_point_image');
 
             ?>
 

--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,7 @@ Theme Name: CC Vocabulary Theme
 Author: the Creative Commons team; possumbilities, Timid Robot
 Author URI: https://opensource.creativecommons.org/
 Description: Theme based on the Vocabulary Design System
-Version: 0.14.0
+Version: 0.15.0
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.0

--- a/src/style.css
+++ b/src/style.css
@@ -657,6 +657,14 @@ main nav.pagination ul li span.current {
 
 /* patches */
 
+.home-narrative main > article:nth-of-type(1) > h2 {
+  margin-top: 0;
+}
+
+.home-narrative main .authored-posts > h2 {
+  margin-top: 0;
+}
+
 .default-page main > aside nav ul {
   font-size: 1rem;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -657,3 +657,10 @@ main nav.pagination ul li span.current {
 
 /* patches */
 
+.default-page main > aside nav ul {
+  font-size: 1rem;
+}
+
+.default-page main > aside nav ul ul {
+  margin-top: .8em;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -664,3 +664,31 @@ main nav.pagination ul li span.current {
 .default-page main > aside nav ul ul {
   margin-top: .8em;
 }
+
+@media (max-width: 900px) {
+
+  .home-narrative .authored-posts.highlight h2 {
+    margin-top: 1em;
+  }
+
+}
+
+@media (max-width: 705px) {
+
+  .search-index .search-form form button {
+    width: 20%;
+  }
+
+  .home-narrative main .authored-posts article {
+    margin-bottom: 2em;
+  }
+
+}
+
+@media (max-width: 425px) {
+
+  .home-narrative main .authored-posts.highlight > article:nth-of-type(1) {
+    padding: 1.2em;
+  }
+
+}


### PR DESCRIPTION
## Description
* add patch fixes to `style.css` 
  - fix nested menu sizing and spacing in the `sidebar`
  - fix responsive bug on `search-index` contexts, `search.php`
  - fix responsive margin bug on `home-index` contexts, `page_home.php`
  - fix h2 top margins on `home-index` contexts, `page_home.php`
* increase Recent Posts on `blog-index` from 5 to 6, so it's symmetrical and fills grid fully, `page_blog.php`
* remove placeholder lead in paragraph from `page-archive.php`
* exclude `Notice` custom post type from search results
* correct image field output for second and third data point image on `home-index`, `page_home.php`
* remove `attention box`  in `sidebar` on `archive-page` context, `page-archive.php`, `archive.php`
* update `primary navigation` to use incoming (post-migration) pages 
* only show backend `Sidebar Meta` settings, if currently set `Page Template` supports display of a `sidebar`
* remove WordPress version information from scraping, disable customize menu, disable build-in GUI file editor
* bump version to `v0.15.0` in `style.css`

## Technical details
* mostly minor render bugs, this puts the MVP at feature completion, and any following releases would be corrections.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
