### PR TITLE
prep for `v0.17.0` release

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,7 @@ Theme Name: CC Vocabulary Theme
 Author: the Creative Commons team; possumbilities, Timid Robot
 Author URI: https://opensource.creativecommons.org/
 Description: Theme based on the Vocabulary Design System
-Version: 0.16.0
+Version: 0.17.0
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.0
@@ -51,6 +51,7 @@ div[id^="attachment_"] img[class^="wp-image"]:not([width]) {
 div[id^="attachment_"] p[id^="caption-attachment-"] {
     display: block;
     margin-top: 1em;
+    font-size: 1em;
 }
 
 div[id^="attachment_"].alignleft {

--- a/src/style.css
+++ b/src/style.css
@@ -679,7 +679,7 @@ main p:has(img) {
 }
 
 .default-page div[id^="attachment_"].alignleft {
-  margin-left: 0
+  margin-left: 0;
   width: 40%;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -658,6 +658,10 @@ main nav.pagination ul li span.current {
 
 /* patches */
 
+main p:has(img) {
+  overflow: hidden;
+}
+
 .home-narrative main > article:nth-of-type(1) > h2 {
   margin-top: 0;
 }
@@ -697,6 +701,10 @@ main nav.pagination ul li span.current {
 
 .team-index main .persons .person h3 {
   width: 100%;
+}
+
+.person-page main > header {
+  min-height: 410px;
 }
 
 body > footer {


### PR DESCRIPTION
## Description
* add patch fixes in `style.css` for:
  - correct mismatch of older image attachment caption sizes, due to differing markup, now matches new markup visually
  - correct overflow of header area of `person-page` context, when picture is present but bio is absent
  - correct horizontal bounds overflow issue on `blog-post` context, from older images that were added within `<p>` tags in content of blog posts.
* bump version to `v0.17.0` in `style.css`
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
