### PR TITLE
add style improvements to top notice banner, along with configurable semantic visual importance levels

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -117,8 +117,12 @@ $noticeQuery = new WP_Query(array(
 ?>
 
 <?php if ( $noticeQuery->have_posts() ) : while ( $noticeQuery->have_posts() ) : $noticeQuery->the_post(); ?>
+<?php if (get_field('importance_level') && get_field('importance_level') != 'default') :
+    $importance_level = get_field('importance_level');
+?>
+<?php endif; ?>
 
-<article class="attention">
+<article class="attention <?php echo $importance_level; ?>">
 <?php the_field('message_rich_text'); ?>
 </article>
 

--- a/src/inc/acf-json/group_64e61a2347108.json
+++ b/src/inc/acf-json/group_64e61a2347108.json
@@ -30,6 +30,42 @@
             "placeholder": ""
         },
         {
+            "key": "field_65494ffa78ac0",
+            "label": "Importance Level",
+            "name": "importance_level",
+            "aria-label": "",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_64e61a2301304",
+                        "operator": "==",
+                        "value": "top-of-site"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "default": "Default",
+                "low-importance": "Low",
+                "medium-importance": "Medium",
+                "high-importance": "High"
+            },
+            "default_value": "default",
+            "return_format": "value",
+            "multiple": 0,
+            "allow_null": 0,
+            "ui": 0,
+            "ajax": 0,
+            "placeholder": ""
+        },
+        {
             "key": "field_64e61c57d938e",
             "label": "Message",
             "name": "message",
@@ -133,5 +169,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1694632325
+    "modified": 1699303892
 }

--- a/src/style.css
+++ b/src/style.css
@@ -708,20 +708,15 @@ body > .attention a {
     background: var(--vocabulary-brand-color-turquoise);
     color: white;
     border-radius: 4px;
-    /* border-top: 1px solid white;
-    border-right: 2px solid white;
-    border-bottom: 3px solid white;
-    border-left: 2px solid white; */
 }
 
 body > .attention a:before {
+  --icon-sprite: url('vocabulary/svg/cc/icons/cc-icons.svg#cc-heart-filled');
   --icon-sprite-color: white;
   --icon-sprite-size: 1em;
 
   display: inline-block;
   content: '';
-  /* min-width: 30px; */
-  /* min-height: 30px; */
   height: 1em;
   width: 1em;
   margin-right: .2em;
@@ -732,12 +727,8 @@ body > .attention a:before {
   mask-repeat: no-repeat;
   -webkit-mask-image: var(--icon-sprite);
   mask-image: var(--icon-sprite);
-
   -webkit-mask-size: contain;
   mask-size: contain;
-
-  --icon-sprite: url('vocabulary/svg/cc/icons/cc-icons.svg#cc-heart-filled');
-
 }
 
 body > .attention.low-importance {

--- a/src/style.css
+++ b/src/style.css
@@ -701,6 +701,25 @@ body > .attention a {
     background: var(--vocabulary-brand-color-turquoise);
     color: white;
     border-radius: 4px;
+    /* border-top: 1px solid white;
+    border-right: 2px solid white;
+    border-bottom: 3px solid white;
+    border-left: 2px solid white; */
+}
+
+body > .attention.low-importance {
+  background: var(--vocabulary-brand-color-soft-green);
+  border-bottom: 8px solid var(--vocabulary-brand-color-green);
+}
+
+body > .attention.medium-importance {
+  background: var(--vocabulary-brand-color-soft-gold);
+  border-bottom: 8px solid var(--vocabulary-brand-color-gold);
+}
+
+body > .attention.high-importance {
+  background: var(--vocabulary-brand-color-soft-tomato);
+  border-bottom: 8px solid var(--vocabulary-brand-color-tomato);
 }
 
 .masthead .identity-logo:focus, body > footer .identity-logo:focus, .icon-replace:focus {

--- a/src/style.css
+++ b/src/style.css
@@ -693,11 +693,18 @@ body > .attention {
 }
 
 body > .attention a {
-    display: inline-block;
-    padding: 0.5em;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5em .8em;;
+
     margin-left: .5em;
 
+    text-transform: uppercase;
+    font-family: 'Roboto Condensed';
+    font-style: normal;
+    font-weight: 700;
     text-decoration: none;
+    vertical-align: middle;
     background: var(--vocabulary-brand-color-turquoise);
     color: white;
     border-radius: 4px;
@@ -705,6 +712,32 @@ body > .attention a {
     border-right: 2px solid white;
     border-bottom: 3px solid white;
     border-left: 2px solid white; */
+}
+
+body > .attention a:before {
+  --icon-sprite-color: white;
+  --icon-sprite-size: 1em;
+
+  display: inline-block;
+  content: '';
+  /* min-width: 30px; */
+  /* min-height: 30px; */
+  height: 1em;
+  width: 1em;
+  margin-right: .2em;
+
+  font-size: var(--icon-sprite-size);
+  background-color: var(--icon-sprite-color);
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-image: var(--icon-sprite);
+  mask-image: var(--icon-sprite);
+
+  -webkit-mask-size: contain;
+  mask-size: contain;
+
+  --icon-sprite: url('vocabulary/svg/cc/icons/cc-icons.svg#cc-heart-filled');
+
 }
 
 body > .attention.low-importance {


### PR DESCRIPTION
## Fixes
* fixes #47 

## Description
The approach here is a default styling, and then three levels of importance based styling.

* **Default:** This is the default styling that is used for the top banner, this enables the area to be distinct, but not disrupt the visual/read flow so the visitor can notice the banner but not have any visual tension or distraction as a result of it.
* **Low:** This is a slight evolution on the Default styling in that it adds a bolder bordering technique to create a small amount of visual tension to disrupt the immediate flow and cause attention to linger longer on the banner before moving further down the flow of the page
* **Medium:** The use of color here, dials up the amount of attention that the box demands, and builds from the visual flow disruption that the "Low" setting allows for
* **High:** The use of color builds once again from Low and Medium's styling and increases the visual presence and flow disruption.

## Screenshots

### Default
<img width="1209" alt="Screen Shot 2023-11-06 at 2 53 26 PM" src="https://github.com/creativecommons/vocabulary-theme/assets/109087089/bd1422ff-82e1-400f-ac56-e62cc3ddd5a8">


### Low
<img width="1211" alt="Screen Shot 2023-11-06 at 2 53 06 PM" src="https://github.com/creativecommons/vocabulary-theme/assets/109087089/27f87abe-73f5-4c72-b955-a16839b4a40d">

### Medium
<img width="1211" alt="Screen Shot 2023-11-06 at 2 52 53 PM" src="https://github.com/creativecommons/vocabulary-theme/assets/109087089/f1d8f878-1917-4f6e-ae94-c96eba7f3a42">

### High
<img width="1210" alt="Screen Shot 2023-11-06 at 2 52 38 PM" src="https://github.com/creativecommons/vocabulary-theme/assets/109087089/4e6e68be-46f0-4419-8b76-5dcf56990ffa">



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
