### PR TITLE
correct for wp img alignment classes on `blog-post` and `default-page` contexts

### DIFF
--- a/src/singular.php
+++ b/src/singular.php
@@ -52,6 +52,8 @@
 
 </header>
 
+<div class="content"
+
 <?php if (!class_exists('ACF')): ?>
 
 <!-- display raw post_meta, if ACF not installed & activated -->
@@ -116,6 +118,8 @@ $query = new WP_Query(array(
     //'paged' => $paged,
 ));
 ?>
+
+</div>
 
 <?php if ( $query->have_posts() ) : ?>
 

--- a/src/style.css
+++ b/src/style.css
@@ -608,9 +608,140 @@ main nav.pagination ul li span.current {
 
 /* patches */
 
-main > article figure img, main > figure img {
+/* main > article figure img, main > figure img {
   width: 100%;
-}
+} */
+ 
 main .content ul, main .content ol {
     line-height: 150%;
+}
+
+/* Classic Editor TinyMCE WYSIWYG editor image alignment  */
+/* TODO: port in alignleft and alignright rules here as well? */
+main figure:has(img.aligncenter) {
+  width: 100%;
+  margin-left: 0;
+}
+
+/* Classic Editor TinyMCE WYSIWYG editor image alignment, previous theme's markukp  */
+/* presently <figure> */
+div[id^="attachment_"] {
+  width: 120%;
+  margin: 0;
+  margin-left: -10%;
+  margin-bottom: 3em;
+  padding: 0;
+  float: none;
+}
+
+/* presently <img> */
+div[id^="attachment_"] img[class^="wp-image"]:not([width]) {
+  width: 100%;
+}
+
+/* presently <span class="attribution> */
+div[id^="attachment_"] p[id^="caption-attachment-"] {
+  display: block;
+  margin-top: 1em;
+  font-size: 1em;
+}
+
+div[id^="attachment_"].alignleft {
+  margin-top: 2em;
+  margin-right: 2em;
+  margin-left: -10%;
+  width: 50%;
+  float: left;
+}
+
+div[id^="attachment_"].alignleft:after {
+  display: block;
+  content: '';
+  height: 3em;
+  clear: both;
+}
+
+div[id^="attachment_"].aligncenter {
+  width: 100%;
+
+  margin-left: 0;
+}
+
+div[id^="attachment_"].alignright {
+  margin-top: 2em;
+  margin-right: -10%;
+  margin-left: 2em;
+  width: 50%;
+  float: right;
+}
+
+div[id^="attachment_"].alignright:after {
+  display: block;
+  content: '';
+  height: 2em;
+  clear: both;
+}
+
+main .content div[id^="attachment_"].alignleft {
+  margin-left: 0;
+  width: 40%;
+}
+
+main .content div[id^="attachment_"].alignright {
+  margin-right: 0;
+  width: 40%;
+}
+
+main .content figure:has(img.alignleft), .blog-post main figure:has(img.alignleft) {
+  margin-right: 2em;
+  margin-left: 0;
+  width: 40%;
+  float: left;
+}
+
+main .content figure:has(img.alignright), .blog-post main figure:has(img.alignright) {
+  margin-right: 0;
+  margin-left: 2em;
+  width: 40%;
+  float: right;
+}
+
+@media (max-width:400px) {
+
+  div[id^="attachment_"].alignleft {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  div[id^="attachment_"].alignright {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  main .content div[id^="attachment_"].alignleft {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+  
+  main .content div[id^="attachment_"].alignright {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  main .content figure:has(img.alignleft), .blog-post main figure:has(img.alignleft) {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
+  main .content figure:has(img.alignright), .blog-post main figure:has(img.alignright) {
+    width: 100%;
+    float: none;
+    margin: 0;
+  }
+
 }


### PR DESCRIPTION
## Description
- incorporates the localized fixes from: 
  - https://github.com/creativecommons/index-prototype/pull/88
- Fixes #98 

**Note:** this rebounds the `blog-post` content to be within a `div.content` wrapper, which fixes the error but violates the grid system in place within Vocabulary. Further explorations are merited to correct for this in the future and reopen the full grid layout capabilities.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
