### PR TITLE
update `vocabulary.css` with `person-page` aspect ratio fix from upstream

### DIFF
--- a/src/vocabulary/css/vocabulary.css
+++ b/src/vocabulary/css/vocabulary.css
@@ -334,7 +334,7 @@ main > aside.sidebar nav.filter-menu ul li.current a {
 main > aside.sidebar nav ul {
     margin: 0;
     padding: 0;
-
+    
     text-indent: none;
     list-style: none;
     font-size: 1rem;
@@ -396,7 +396,7 @@ main h2 {
 
 main h3 {
     box-sizing: border-box;
-
+    
     font-family: 'Roboto Condensed';
     font-style: normal;
     font-weight: 700;
@@ -640,7 +640,7 @@ main article.posts.related .post header {
 
 main article.posts.related .post figure {
     display: none;
-    order: -1;
+    order: -1; 
 }
 
 main article.posts.related .post a {
@@ -666,7 +666,7 @@ main nav.pagination ol {
     width: 100%;
     margin: 0;
     padding: 0;
-
+    
     text-indent: none;
     font-size: 1em;
     list-style: none;
@@ -702,7 +702,7 @@ main .attribution-list {
     grid-column: 3 / span 7;
     box-sizing: border-box;
     position: relative;
-    padding: 4em;
+    padding: 4em; 
 
     background: var(--vocabulary-neutral-color-lighter-gray);
     text-align: left;
@@ -1525,7 +1525,7 @@ body > footer .license svg {
     order: initial;
 }
 
-.blog-index main .posts.featured ul {
+.blog-index main .posts.featured ul {    
     padding: 0 var(--vocabulary-page-edges-space);
 }
 
@@ -1747,14 +1747,14 @@ body > footer .license svg {
     top: 3.4em;
     left: 0;
     width: 30%;
+    max-height: 21.8rem;
+    overflow: hidden;
+    border: 16px solid white;
 }
 
 .person-page main > header figure img {
     box-sizing: border-box;
     width: 100%;
-    max-height: 21.8rem;
-
-    border: 16px solid white;
 }
 
 .person-page main > header .bio {
@@ -1957,7 +1957,7 @@ body > footer .license svg {
         padding: 0 var(--vocabulary-page-edges-space);
     }
 
-    main:has( > aside.sidebar) > aside.sidebar {
+    main:has( > aside.sidebar) > aside.sidebar { 
         padding: 0 var(--vocabulary-page-edges-space);
     }
 
@@ -1966,7 +1966,7 @@ body > footer .license svg {
     }
 
     main > .posts {
-        padding: 0 var(--vocabulary-page-edges-space);
+        padding: 0 var(--vocabulary-page-edges-space); 
     }
 
     .posts article figure {
@@ -1979,7 +1979,7 @@ body > footer .license svg {
         padding-right: var(--vocabulary-page-edges-space);
     }
 
-    .person-page main > header:before {
+    .person-page main > header:before { 
         left: 0;
     }
 
@@ -1988,10 +1988,10 @@ body > footer .license svg {
         padding-right: var(--vocabulary-page-edges-space);
     }
 
-    .search-index main > header:before {
+    .search-index main > header:before { 
         left: 0;
     }
-
+    
     .team-index main > header {
         padding: 0 var(--vocabulary-page-edges-space);
     }


### PR DESCRIPTION
## Description
* pulls in aspect ratio fix from upstream `vocabulary` for `person-page` profile image
  - https://github.com/creativecommons/vocabulary/pull/348


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
