### PR TITLE
correct markup for display of opening `aside` on `blog-post` context

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -57,11 +57,11 @@
 
 <div class="content">
 
-<!-- <div class="series">
+<!-- <aside class="opening">
     <span>part of the</span>
     <a href="#">Copyright and Artists</a> series, a unique take on how copyright isn't aligned with the interests of individual artists, but instead mega-corps.
 
-    </div> -->
+</aside> -->
 
     <?php the_content(); ?>
 

--- a/src/singular.php
+++ b/src/singular.php
@@ -58,17 +58,17 @@
 
 <!-- display raw post_meta, if ACF not installed & activated -->
 <?php if (get_post_meta( get_the_ID(), 'lead_in_copy', true )): ?>
-<div class="series">
+<aside class="opening">
     <?php echo get_post_meta( get_the_ID(), 'lead_in_copy', true ); ?>
-</div>
+</aside>
 <?php endif; ?>
 <?php else : ?>
 
 <!-- display ACF field, if ACF installed & activated -->
 <?php if (get_field('lead_in_copy')): ?>
-<div class="series">
+<aside class="opening">
     <?php the_field('lead_in_copy'); ?>
-</div>
+</aside>
 <?php endif; ?>
 <?php endif; ?>
 


### PR DESCRIPTION
## Description
- fixes #116 

## Technical details
The wrapping markup around this element shifted upstream, but was missed in a previous PR. This has now been corrected so that the corresponding CSS within vocabulary once again applies correctly.

## Screenshots

### Before
<img width="891" alt="Screen Shot 2025-05-15 at 1 54 47 PM" src="https://github.com/user-attachments/assets/3248ecaf-060a-4a76-8803-e42df35e5e09" />

### After
<img width="915" alt="Screen Shot 2025-05-15 at 1 55 31 PM" src="https://github.com/user-attachments/assets/bf3f1101-0de7-47fc-b262-d88a30bab50e" />



## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
