### PR TITLE
adjust display `of course-page` for `embedded` course context with Canvas platform

### DIFF
--- a/src/single-course.php
+++ b/src/single-course.php
@@ -56,9 +56,6 @@ $aunts = get_children($grandparent->ID);
 
 <nav class="breadcrumbs">
     <ul>
-        <?php if ($embedded == true ) : ?>
-        <li>Creative Commons</li>
-        <?php endif; ?>
         <?php if($contextType == 'course-index' && $embedded == '') : ?>
         <li><a href="https://creativecommons.org">Creative Commons</a></li>
         <?php endif; ?>
@@ -66,7 +63,7 @@ $aunts = get_children($grandparent->ID);
         <li><a href="https://creativecommons.org">Creative Commons</a></li>
         <?php endif; ?>
 
-        <?php if ($contextType != 'course-index' ) : ?>
+        <?php if ($contextType != 'course-index' && $embedded == '') : ?>
         <li><a href="<?php the_permalink($grandparent->ID); ?>"><?php echo $grandparent->post_title; ?></a></li>
 
         <?php endif; ?>

--- a/src/style.css
+++ b/src/style.css
@@ -1011,6 +1011,14 @@ main .content figure:has(img.alignright), .blog-post main figure:has(img.alignri
   float: right;
 }
 
+.course-index, course-page {
+  background: white;
+}
+
+.course-page main .content {
+  grid-column: 2 / span 9;
+}
+
 @media (max-width:400px) {
 
   div[id^="attachment_"].alignleft {


### PR DESCRIPTION
## Description
* explicitly sets background of the `body` on `course-page` and `course-index` context to white (to override Canvas settings within `iframe` embed
* hides the `breadcrumb nav` on `course-page` when embedded
* widens `main .content` on `course-page` to better fit within embed `iframe` in Canvas

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
