### PR TITLE
add past, upcoming, and default (all) events listing capabilities, corrects attribution display on `single-event.php`, bumps `style.css` to `v2.5`

### DIFF
--- a/src/archive-event.php
+++ b/src/archive-event.php
@@ -45,7 +45,22 @@
     </ol>
 </nav> -->
 
-<h1><?php the_archive_title(); ?></h1>
+<?php
+
+global $wp;
+if (array_key_exists('filtered', $wp->query_vars) && isset($wp->query_vars['filtered'])) {
+    if ($wp->query_vars['filtered'] == 'past') {
+        $eventsFiltered = 'Past';
+    } elseif ($wp->query_vars['filtered'] == 'future') {
+        $eventsFiltered = 'Upcoming';
+    } else {
+        $eventsFiltered = '';
+    }
+}
+
+?>
+
+<h1><?php the_archive_title(); ?><?php if(!empty($eventsFiltered)) {echo ', '.$eventsFiltered;} ?></h1>
 
 <p><?php the_archive_description(); ?></p>
 

--- a/src/archive-event.php
+++ b/src/archive-event.php
@@ -68,6 +68,20 @@ if (array_key_exists('filtered', $wp->query_vars) && isset($wp->query_vars['filt
 </header>
 
 
+<aside class="sidebar">   
+
+    <nav class="filter-menu">
+        <h2>Related Links</h2>
+        <ul>
+            <li class="<?php if($eventsFiltered == ''){echo 'current';} ?>"><a href="/events-archive/?filtered=all">All</a></li>
+            <li class="<?php if($eventsFiltered == 'Upcoming'){echo 'current';} ?>"><a href="/events-archive/?filtered=future">Upcoming</a></li>
+            <li class="<?php if($eventsFiltered == 'Past'){echo 'current';} ?>"><a href="/events-archive/?filtered=past">Past</a></li>
+        </ul>
+    </nav>
+
+</aside>
+
+
 
 <article class="posts">
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -302,7 +302,7 @@ function customize_event_archive_display ( $query ) {
         global $wp;
         if (array_key_exists('filtered', $wp->query_vars) && isset($wp->query_vars['filtered'])) {
             if ($wp->query_vars['filtered'] == 'past') {
-                if ($query->is_main_query()) {
+                if ($query->is_main_query() && is_post_type_archive( 'event' )) {
                   // $query->set( 'post_type', 'event' );                 
                   $query->set( 'meta_key', 'event_date' );  
                   $query->set( 'meta_compare', '<' );

--- a/src/functions.php
+++ b/src/functions.php
@@ -296,12 +296,34 @@ function add_filtered() {
 
 // alter query params for loop on events-archive
 function customize_event_archive_display ( $query ) {
-        if ($query->is_main_query()) {
-          // TODO: customize to specifics
-          // $query->set( 'post_type', 'event' );                 
-          // $query->set( 'meta_key', 'event_date' );           
-          // $query->set( 'orderby', 'meta_value' );
-          // $query->set( 'order', 'ASC' );
+
+        $today = date('Ymd', strtotime("now"));
+
+        global $wp;
+        if (array_key_exists('filtered', $wp->query_vars) && isset($wp->query_vars['filtered'])) {
+            if ($wp->query_vars['filtered'] == 'past') {
+                if ($query->is_main_query()) {
+                  // $query->set( 'post_type', 'event' );                 
+                  $query->set( 'meta_key', 'event_date' );  
+                  $query->set( 'meta_compare', '<' );
+                  $query->set( 'meta_type', 'numberic' );
+                  $query->set( 'meta_value', $today );         
+                  $query->set( 'orderby', 'meta_value_num' );
+                  $query->set( 'order', 'ASC' ); 
+                }
+            } elseif ($wp->query_vars['filtered'] == 'future') {
+                if ($query->is_main_query()) {
+                  // $query->set( 'post_type', 'event' );                 
+                  $query->set( 'meta_key', 'event_date' );  
+                  $query->set( 'meta_compare', '>=' );
+                  $query->set( 'meta_type', 'numberic' );
+                  $query->set( 'meta_value', $today );         
+                  $query->set( 'orderby', 'meta_value_num' );
+                  $query->set( 'order', 'ASC' ); 
+                }
+            } else {
+                // do nothing
+            }
         }
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -285,6 +285,14 @@ function add_embedded() {
     $wp->add_query_var('embedded');
 }
 
+// register custom filter URL parameter for events-archive template
+
+add_action('init','add_filtered');
+function add_filtered() {
+    global $wp;
+    $wp->add_query_var('filtered');
+}
+
 // remove edit_post_link from non-editors
 function remove_get_edit_post_link( $link ) {
   if ( current_user_can( 'edit_posts' ) ) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -293,6 +293,20 @@ function add_filtered() {
     $wp->add_query_var('filtered');
 }
 
+
+// alter query params for loop on events-archive
+function customize_event_archive_display ( $query ) {
+        if ($query->is_main_query()) {
+          // TODO: customize to specifics
+          // $query->set( 'post_type', 'directory' );                 
+          // $query->set( 'meta_key', 'event_date' );           
+          // $query->set( 'orderby', 'meta_value' );
+          // $query->set( 'order', 'ASC' );
+        }
+    }
+
+add_action( 'pre_get_posts', 'customize_event_archive_display' );
+
 // remove edit_post_link from non-editors
 function remove_get_edit_post_link( $link ) {
   if ( current_user_can( 'edit_posts' ) ) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -298,7 +298,7 @@ function add_filtered() {
 function customize_event_archive_display ( $query ) {
         if ($query->is_main_query()) {
           // TODO: customize to specifics
-          // $query->set( 'post_type', 'directory' );                 
+          // $query->set( 'post_type', 'event' );                 
           // $query->set( 'meta_key', 'event_date' );           
           // $query->set( 'orderby', 'meta_value' );
           // $query->set( 'order', 'ASC' );

--- a/src/pidgin/page_events.php
+++ b/src/pidgin/page_events.php
@@ -114,6 +114,80 @@
 
 </article>
 
+<article class="events">
+    <h2>Recent Events</h2>
+    <ul>
+
+    <?php
+
+    $today = date('Ymd', strtotime("now")); 
+
+    $query = new WP_Query(array(
+        'post_type' => 'event',
+        'posts_per_page' => 4,
+        'meta_key' => 'event_date',
+		'meta_compare' => '<',
+        'meta_type' => 'numeric',
+		'meta_value' => array($today),
+		'orderby' => 'meta_value_num',
+		'order' => 'ASC'
+        //'paged' => $paged,
+    ));
+    ?>
+
+    <?php if ( $query->have_posts() ) : while ( $query->have_posts() ) : $query->the_post(); ?>
+
+    <?php
+
+    $date = DateTime::createFromFormat('Ymd', get_field('event_date'));
+   
+    ?>
+
+        <li>
+            <article class="event">
+
+                <div class="description">
+                <h3><?php the_title(); ?></h3>
+                <h4><?php echo $date->format('F j, Y'); ?></h4>
+                <span class="time"><?php the_field('event_time_start'); ?> - <?php the_field('event_time_end'); ?> <?php the_field('event_timezone'); ?></span>
+                <span class="location"><?php the_field('event_location'); ?></span>
+
+                <p><?php echo wp_trim_words($excerpt, 50); ?></p>
+
+                <a href="<?php echo the_permalink(); ?>">See Event Details</a>
+                </div>
+
+                <figure>
+
+                    <img src="<?php echo get_the_post_thumbnail_url( $post_id, 'large' ); ?>" alt="<?php echo get_post_meta ( get_post_thumbnail_id($post_id), '_wp_attachment_image_alt', true ); ?>" />
+
+
+                    <!-- <svg class="shape1">
+                        <use href="../../../../pidgin/svg/blob3.svg"></use>
+                    </svg> -->
+
+                    <figcaption>
+                        <!-- <p>attribution details here</p> -->
+                         <p><?php echo get_the_post_thumbnail_caption( $post_id ); ?></p>
+                        
+                    </figcaption>
+                </figure>
+
+            </article>
+        </li>
+
+        <?php endwhile; ?>
+        <?php endif; ?>
+
+    </ul>
+
+    <footer>
+        <a class="more" href="/events-archive/?filtered=past">more events</a>
+    </footer>
+
+
+</article>
+
 <?php get_template_part( 'pidgin/content-partials/pidgin', 'newsletter_promo', '' ); ?>
 
 </main>

--- a/src/single-event.php
+++ b/src/single-event.php
@@ -71,8 +71,8 @@ $date = DateTime::createFromFormat('Ymd', get_field('event_date'));
                     <h4><?php echo $position_title; ?></h4>
                     <p><?php echo wp_trim_words($excerpt, 50); ?></p>
 
-                    <?php if (get_the_post_thumbnail_caption( $post_id )) : ?>
-                    <p class="caption">attribution: <?php echo get_the_post_thumbnail_caption( $post_id ); ?></p>
+                    <?php if (get_the_post_thumbnail_caption( $speaker_person->ID )) : ?>
+                    <p class="caption">attribution: <?php echo get_the_post_thumbnail_caption( $speaker_person->ID ); ?></p>
                     <?php endif; ?>
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,7 @@ Theme Name: CC Vocabulary Theme
 Author: the Creative Commons team; possumbilities, Timid Robot
 Author URI: https://opensource.creativecommons.org/
 Description: Theme based on the Vocabulary Design System
-Version: 2.4
+Version: 2.5
 Requires at least: 5.0
 Tested up to: 6.2.2
 Requires PHP: 7.0


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
- adds params based filters for `events-archive` template
- setups up hook in `functions.php` to change parameters used in query loop for `/events-archive`
- corrects display of attribution caption on `speaker` on `single-event.php`
- adds sidebar to `/events-archive` (similar to `/blog`) for filtering by `all`, `upcoming`, and `past` events; sets default to `upcoming`
- adds new section to `/events` to display a small subsection of recent "past event", with a more button to navigate to a pre-filtered `/events-archive/?filtered=past` page.
- bumps `style.css` to `v2.5`


## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

The events archive page at `/events-archive` can now be filtered to all:`empty`, past:`past`, or upcoming:`future` with the following query parameters appended to the URL

- `/events-archive/` | `/events-archive/?filtered=all`
- `/events-archive/?filtered=past`
- `/events-archive/?filtered=future`

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
1. create a Page, give it the Events Index template
2. create a few placeholder events
3. see results
4. Visit the /events-archive page
5. see results

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
