### PR TITLE
correct typography, correct link display, correct pathways in ACF data for new template locations

### DIFF
--- a/src/chooser/css/chooser.css
+++ b/src/chooser/css/chooser.css
@@ -249,7 +249,7 @@
 .chooser-page #tool-recommendation h3 {
     margin: 0;
 
-    font-family: 'Source Sans Pro';
+    font-family: 'DM Sans';
     font-size: 1.4em;
 }
 

--- a/src/chooser/css/chooser.css
+++ b/src/chooser/css/chooser.css
@@ -83,6 +83,19 @@
 .chooser-page .hide {
     display: none;
 }
+    
+.chooser-page > header p {
+  text-align: left;
+  margin-bottom: 0;
+}
+
+.chooser-page header p:nth-child(2) {
+  font-size: 1.3em;
+}
+
+.chooser-page > footer  {
+  margin-top: 8em;
+}    
 
 .chooser-page .tool header {
     display: flex;
@@ -96,6 +109,10 @@
 .chooser-page .tool header > .tool-icons {
     order: -1;
     margin: 0 1em 0 0;
+}
+
+.chooser-page main h3 {
+  font-family: "DM Sans";
 }
 
 .chooser-page .tool .tool-icons svg {
@@ -159,6 +176,7 @@
 
 .chooser-page form#chooser fieldset {
     margin-bottom: 1em;
+    border-radius: 12px;
 }
 
 .chooser-page form#chooser label {
@@ -180,7 +198,7 @@
 
 .chooser-page form#chooser #attribution-details div {
     margin-bottom: .5em;
-}
+} 
 
 .chooser-page form#chooser #waive-your-copyright div {
     margin-bottom: 1em;
@@ -202,6 +220,7 @@
 
     background: var(--vocabulary-brand-color-soft-turquoise);
     background: var(--vocabulary-neutral-color-lighter-gray);
+    border-radius: 16px;
 }
 
 .chooser-page aside #empty p {
@@ -217,11 +236,14 @@
 .chooser-page #tool-recommendation .tool {
     padding: 2em;
 
-    background: var(--vocabulary-brand-color-soft-turquoise);
+    background:#FFD9CC;
+    border-radius: 16px;
 }
 
 .chooser-page #tool-recommendation .tool a {
-    --underline-background-color: var(--vocabulary-brand-color-soft-turquoise);
+    --underline-background-color: #FFD9CC;
+
+    font-family: "DM Sans";
 }
 
 .chooser-page #tool-recommendation h3 {
@@ -234,7 +256,7 @@
 .chooser-page #tool-recommendation h4 {
     margin: .2em;
 
-    font-family: 'Source Sans Pro';
+    font-family: "DM Sans";
     font-size: 1.4em;
 }
 
@@ -249,7 +271,7 @@
 .chooser-page #tool-recommendation .conditions-definitions {
     margin-bottom: 2em;
 
-    font-family: 'Source Sans Pro';
+    font-family: "DM Mono";
 }
 
 .chooser-page #tool-recommendation .conditions-definitions dt {
@@ -267,7 +289,7 @@
     font-size: 1.2em;
 }
 
-.chooser-page details {
+.chooser-page details { 
     font-family: 'Source Sans Pro';
 
     border: 2px solid var(--vocabulary-neutral-color-lighter-gray);
@@ -281,11 +303,12 @@
 .chooser-page details.medium {
     margin-bottom: 1em;
 }
-
+  
 .chooser-page details summary {
     padding: .2em .5em;
 
     background: var(--vocabulary-neutral-color-lighter-gray);
+    font-family: "DM Sans";
     font-size: 1.6em;
 }
 
@@ -296,7 +319,7 @@
 .chooser-page summary:hover {
     cursor: pointer;
 }
-
+  
 .chooser-page summary::marker {
     font-size: .8em;
 }

--- a/src/inc/acf-json/group_64e504efda65e.json
+++ b/src/inc/acf-json/group_64e504efda65e.json
@@ -287,5 +287,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1773073676
+    "modified": 1782326442
 }

--- a/src/inc/acf-json/group_69021421a5430.json
+++ b/src/inc/acf-json/group_69021421a5430.json
@@ -934,7 +934,7 @@
             {
                 "param": "page_template",
                 "operator": "==",
-                "value": "pidgin\/page_home-narrative.php"
+                "value": "page_home-narrative.php"
             }
         ]
     ],
@@ -949,5 +949,5 @@
     "active": false,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1772053608
+    "modified": 1782326579
 }

--- a/src/inc/acf-json/group_69a5acadb51e9.json
+++ b/src/inc/acf-json/group_69a5acadb51e9.json
@@ -39,7 +39,7 @@
             {
                 "param": "page_template",
                 "operator": "==",
-                "value": "pidgin\/page_home-narrative.php"
+                "value": "page_home-narrative.php"
             }
         ]
     ],
@@ -54,5 +54,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1772558692
+    "modified": 1782326488
 }

--- a/src/inc/acf-json/group_69a5ce6d14887.json
+++ b/src/inc/acf-json/group_69a5ce6d14887.json
@@ -1062,7 +1062,7 @@
             {
                 "param": "page_template",
                 "operator": "==",
-                "value": "pidgin\/page_licenses.php"
+                "value": "page_licenses.php"
             }
         ]
     ],
@@ -1075,5 +1075,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1772568434
+    "modified": 1782326619
 }

--- a/src/inc/acf-json/group_69a6ff148ac7b.json
+++ b/src/inc/acf-json/group_69a6ff148ac7b.json
@@ -360,7 +360,7 @@
             {
                 "param": "page_template",
                 "operator": "==",
-                "value": "pidgin\/page_support.php"
+                "value": "page_support.php"
             }
         ]
     ],
@@ -375,5 +375,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1772568383
+    "modified": 1782326528
 }

--- a/src/inc/acf-json/group_69a70c6f744f9.json
+++ b/src/inc/acf-json/group_69a70c6f744f9.json
@@ -848,7 +848,7 @@
             {
                 "param": "page_template",
                 "operator": "==",
-                "value": "pidgin\/page_training.php"
+                "value": "page_training.php"
             }
         ]
     ],
@@ -863,5 +863,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1775745352
+    "modified": 1782326556
 }

--- a/src/vocabulary/css/vocabulary.css
+++ b/src/vocabulary/css/vocabulary.css
@@ -287,25 +287,25 @@ article.topic-summary.focus-area:nth-of-type(even) figure {
     order: -1;
 }
 
-article:nth-child(3n + 2 of .topic-summary.focus-area) a {
+article:nth-child(3n + 2 of .topic-summary.focus-area) > a {
     --underline-background-color: #ADFF00;
     background:#ADFF00;
     color: black;
 }
 
-article:nth-child(3n + 3 of .topic-summary.focus-area) a {
+article:nth-child(3n + 3 of .topic-summary.focus-area) > a {
     --underline-background-color: #2E1FB8;
     background:#2E1FB8;
     color: white;
 }
 
-article:nth-child(3n + 1 of .topic-summary.focus-area) a {
+article:nth-child(3n + 1 of .topic-summary.focus-area) > a {
     --underline-background-color: #FF9CFF;
     background:#FF9CFF;
     color: black;
 }
 
-article.topic-summary.focus-area a:hover {
+article.topic-summary.focus-area > a:hover {
     --underline-background-color: #black;
     background:black;
     color: white;
@@ -313,6 +313,28 @@ article.topic-summary.focus-area a:hover {
     /* padding: .8em 1.8em; */
 
     /* border: none; */
+}
+
+article.topic-summary p a {
+    --underline-background-color: none;
+    display: inline;
+    background: none;
+    border: none;
+    margin: 0;
+    padding: 0;
+    color: inherit;
+    font-size: 1em;
+    font-weight: 400;
+    text-transform: none;
+    color: #2E1FB8;
+    text-decoration: underline;
+}
+
+article.topic-summary p a:hover {
+    --underline-background-color: none;
+    
+    border: none;
+    background: none;
 }
 
 /* post component - singular */
@@ -3071,7 +3093,7 @@ body > footer .license p a:hover {
     order: -1;
 
     font-family: "DM Sans";
-    font-size: 3.2em;
+    font-size: 1.5em;
     color:#2E1FB8;
 }
 


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Description
<!-- Concisely describe what the pull request does. -->
- corrects sizing of type
- corrects display of links outside of expected button presentation on `.topic-summary` and `focus-area` `articles`
- updates the JSON data location of templates used by ACF fields
- reintroduces the newer stylings of the chooser into the chooser properly, and not as patches

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

- This PR makes several downstream changes to `vocabulary.css` which will need to be added upstream to Vocabulary
- The PR also makes changes to downstream chooser, which will need to be added to upstream chooser

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

1. Visit the support page template to verify links display correctly
2. Edit any page utilizing a new template to verify the correct template loads with appropriate fields
3. visit the chooser to verify correct stylings load
4. visit events listing page to verify typography renders correctly

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
